### PR TITLE
Add basic Electron + React launcher skeleton

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true,
+    "jest": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# minecraft-launcher
-test of a minecraft launcher
+# Minecraft Launcher (Example)
+
+This repository contains a minimal example of a Minecraft launcher built with Electron and React. It is intended as a starting point for a full implementation.
+
+## Prerequisites
+- Node.js >= 18
+- npm
+
+## Getting Started
+
+```bash
+# Clone the repository
+git clone <repo-url>
+cd minecraft-launcher
+
+# Install dependencies
+npm install
+
+# Start in development mode
+npm run dev
+```
+
+## Packaging
+
+```bash
+npm run build
+npm run package
+```
+
+## Testing and Linting
+
+```bash
+npm test
+npm run lint
+```
+
+For more details on the UI design see `design.md`.

--- a/design.md
+++ b/design.md
@@ -1,0 +1,8 @@
+# Design Overview
+
+The launcher uses a dark theme with a video background to give a modern look. The main play button is centered and glows on hover to draw attention. The overlay uses a semi-transparent black background to keep text legible over the video.
+
+- **Primary color:** `#33ff33` for the play button glow.
+- **Background:** full-screen looping video.
+- **Layout:** flexbox centered content.
+- **Animations:** CSS transitions for the play button.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests']
+};

--- a/libs/launcher.js
+++ b/libs/launcher.js
@@ -1,0 +1,10 @@
+// Placeholder wrapper around minecraft-launcher-core
+// In a real implementation, this would use the library to download and launch the game.
+
+async function launch(options) {
+  // TODO: integrate minecraft-launcher-core and handle authentication, download and launch
+  console.log('Launching Minecraft with options', options);
+  return { success: true };
+}
+
+module.exports = { launch };

--- a/main.js
+++ b/main.js
@@ -1,0 +1,37 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+
+// Create the main window
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 720,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+    },
+    backgroundColor: '#000000',
+    show: false,
+  });
+
+  win.once('ready-to-show', () => win.show());
+  win.loadFile(path.join(__dirname, 'renderer/public/index.html'));
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', function () {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') app.quit();
+});
+
+// Example IPC for launching the game
+ipcMain.handle('launch', async (event, opts) => {
+  const launcher = require('./libs/launcher');
+  return launcher.launch(opts);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "minecraft-launcher",
+  "version": "0.1.0",
+  "description": "Example Minecraft launcher using Electron and React",
+  "main": "main.js",
+  "scripts": {
+    "dev": "electron .",
+    "lint": "eslint .",
+    "test": "jest",
+    "build": "echo build placeholder",
+    "package": "echo package placeholder"
+  },
+  "devDependencies": {
+    "electron": "^27.0.0",
+    "eslint": "^8.0.0",
+    "jest": "^29.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,6 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+// Expose a limited API to the renderer
+contextBridge.exposeInMainWorld('api', {
+  launch: (options) => ipcRenderer.invoke('launch', options),
+});

--- a/renderer/public/index.html
+++ b/renderer/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Minecraft Launcher</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="../src/index.jsx" type="module"></script>
+</body>
+</html>

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import PlayButton from './components/PlayButton.jsx';
+
+export default function App() {
+  return (
+    <div className="app-container">
+      <video autoPlay loop muted className="background-video">
+        <source src="background.mp4" type="video/mp4" />
+      </video>
+      <div className="overlay">
+        <PlayButton />
+      </div>
+    </div>
+  );
+}

--- a/renderer/src/components/PlayButton.jsx
+++ b/renderer/src/components/PlayButton.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function PlayButton() {
+  const handleClick = () => {
+    window.api.launch({});
+  };
+
+  return (
+    <button className="play-button" onClick={handleClick}>
+      Jouer
+    </button>
+  );
+}

--- a/renderer/src/index.jsx
+++ b/renderer/src/index.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+import './styles/App.css';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/renderer/styles/App.css
+++ b/renderer/styles/App.css
@@ -1,0 +1,51 @@
+html, body, #root {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  font-family: sans-serif;
+  background: #000;
+}
+
+.app-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.background-video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.play-button {
+  padding: 20px 40px;
+  font-size: 1.5rem;
+  color: #fff;
+  background: rgba(50, 150, 50, 0.8);
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.play-button:hover {
+  transform: scale(1.1);
+  box-shadow: 0 0 20px #33ff33;
+}

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,3 @@
+test('dummy test', () => {
+  expect(1 + 1).toBe(2);
+});


### PR DESCRIPTION
## Summary
- scaffold simple Electron + React app
- add example launcher wrapper
- include basic styling and design notes
- document installation and usage instructions
- add Jest test and ESLint config

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687ab9918bac8322a17adc7690471310